### PR TITLE
LAB-950: Fix terrain starry skies

### DIFF
--- a/Source/Renderer/ComputeCommand.js
+++ b/Source/Renderer/ComputeCommand.js
@@ -74,6 +74,14 @@ define([
         this.postExecute = options.postExecute;
 
         /**
+         * Function that is called when the command is canceled
+         *
+         * @type {Function}
+         * @default undefined
+         */
+        this.canceled = options.canceled;
+
+        /**
          * Whether the renderer resources will persist beyond this call. If not, they
          * will be destroyed after completion.
          *

--- a/Source/Scene/ImageryLayer.js
+++ b/Source/Scene/ImageryLayer.js
@@ -983,6 +983,10 @@ define([
                         that._finalizeReprojectTexture(context, outputTexture);
                         imagery.state = ImageryState.READY;
                         imagery.releaseReference();
+                    },
+                    canceled : function() {
+                        imagery.state = ImageryState.TEXTURE_LOADED;
+                        imagery.releaseReference();
                     }
                 });
                 this._reprojectComputeCommands.push(computeCommand);
@@ -1017,6 +1021,11 @@ define([
      * @private
      */
     ImageryLayer.prototype.cancelReprojections = function() {
+        this._reprojectComputeCommands.forEach(function(command) {
+            if (command.canceled) {
+                command.canceled();
+            }
+        });
         this._reprojectComputeCommands.length = 0;
     };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@propelleraero/cesium",
-  "version": "1.61.0",
+  "version": "1.61.1",
   "description": "CesiumJS is a JavaScript library for creating 3D globes and 2D maps in a web browser without a plugin.",
   "homepage": "http://cesiumjs.org",
   "license": "Apache-2.0",


### PR DESCRIPTION
* Add cancel command to ComputeCommand to ensure re-projection commands which are cancelled during transition to be set to a state which does not cause the imagery tile state machine to be stuck