### PR TITLE
LAB-1659 Rework codeship to run from release tag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,7 @@ yarn.lock
 # WebStorm user-specific
 .idea/workspace.xml
 .idea/tasks.xml
+
+# Codeship
+deployment/secrets
+deployment/*.aes

--- a/.npmignore
+++ b/.npmignore
@@ -29,5 +29,5 @@
 /ThirdParty
 /Tools
 /web.config
-
+/deployment
 Thumbs.db

--- a/README-PROPELLER.md
+++ b/README-PROPELLER.md
@@ -1,0 +1,51 @@
+# Updating the Propeller fork of Cesium
+
+"The best way in my eyes is, to rebase because that fetches the latest changes of the upstream branch and replay your work on top of that." - [Stefan Bauer](https://stefanbauer.me/articles/how-to-keep-your-git-fork-up-to-date)
+
+The ideal git history should have all Propeller modifications in a single most recent commit, followed by the full history from upstream CesiumGS.
+
+e.g.
+
+```
+commit c6fc9cb205e387781c5269b95e350f61a8815d08
+Author: Chris Cooper <chris@propelleraero.com>
+Date:   Mon Sep 21 15:19:02 2020 +1000
+
+    All the Propeller mods in a single commit
+
+commit da4ddc58830606d89f762dc7d79b3dfe4103c6d1
+Merge: 9c61508 6c0a0f8
+Author: Kevin Ring <kevin@kotachrome.com>
+Date:   Tue Sep 1 15:47:38 2020 +1000
+
+    Updates for 1.73 release
+
+...
+```
+
+To maintain this going forward, use a `git rebase`.
+
+```
+# Make sure your master branch is up to date
+git checkout master
+git pull
+
+# Work from a branch for now
+git checkout -b 'my-update-branch'
+
+# Fetch the upstream tags
+git fetch upstream --tags
+
+# Interactive rebase to the CesiumGS release tag
+# Squash all propeller commits into a single commit
+git rebase -i 1.74
+
+# Once you're certain your branch is working as expected
+# E.g. you've tested by yarn link into visualiser
+# Then reset master to match your branch
+git checkout master
+git reset my-update-branch --hard
+
+# Now you can run the release script to tag and publish
+./release.sh
+```

--- a/Source/Core/ApproximateTerrainHeights.js
+++ b/Source/Core/ApproximateTerrainHeights.js
@@ -47,6 +47,11 @@ ApproximateTerrainHeights.initialize = function () {
   initPromise = Resource.fetchJson(
     buildModuleUrl("Assets/approximateTerrainHeights.json")
   ).then(function (json) {
+    // PROPELLER HACK: Allow rendering of ground primitives with negative WGS84 elevation
+    var MAX_HOLE_DEPTH = 250;
+    Object.keys(json).map(function (key) {
+      json[key][0] -= MAX_HOLE_DEPTH;
+    });
     ApproximateTerrainHeights._terrainHeights = json;
   });
   ApproximateTerrainHeights._initPromise = initPromise;

--- a/Source/Core/GroundPolylineGeometry.js
+++ b/Source/Core/GroundPolylineGeometry.js
@@ -40,7 +40,8 @@ var MITER_BREAK_LARGE = Math.cos(CesiumMath.toRadians(150.0));
 // Ellipsoid height is generally much closer.
 // The initial max height is arbitrary.
 // Both heights are corrected using ApproximateTerrainHeights for computing the actual volume geometry.
-var WALL_INITIAL_MIN_HEIGHT = 0.0;
+// PROPELLER HACK: Allow rendering of ground primitives with negative WGS84 elevation
+var WALL_INITIAL_MIN_HEIGHT = -250;
 var WALL_INITIAL_MAX_HEIGHT = 1000.0;
 
 /**

--- a/Source/Core/sampleTerrain.js
+++ b/Source/Core/sampleTerrain.js
@@ -1,5 +1,6 @@
 import when from "../ThirdParty/when.js";
 import Check from "./Check.js";
+import defaultValue from "./defaultValue";
 
 /**
  * Initiates a terrain height query for an array of {@link Cartographic} positions by
@@ -37,7 +38,13 @@ import Check from "./Check.js";
  *     // updatedPositions is just a reference to positions.
  * });
  */
-function sampleTerrain(terrainProvider, level, positions) {
+// PROPELLER HACK
+function sampleTerrain(
+  terrainProvider,
+  level,
+  positions,
+  failResultOnTileFail
+) {
   //>>includeStart('debug', pragmas.debug);
   Check.typeOf.object("terrainProvider", terrainProvider);
   Check.typeOf.number("level", level);
@@ -45,11 +52,12 @@ function sampleTerrain(terrainProvider, level, positions) {
   //>>includeEnd('debug');
 
   return terrainProvider.readyPromise.then(function () {
-    return doSampling(terrainProvider, level, positions);
+    // PROPELLER HACK
+    return doSampling(terrainProvider, level, positions, failResultOnTileFail);
   });
 }
-
-function doSampling(terrainProvider, level, positions) {
+// PROPELLER HACK
+function doSampling(terrainProvider, level, positions, failResultOnTileFail) {
   var tilingScheme = terrainProvider.tilingScheme;
 
   var i;
@@ -88,9 +96,17 @@ function doSampling(terrainProvider, level, positions) {
       tileRequest.y,
       tileRequest.level
     );
-    var tilePromise = requestPromise
-      .then(createInterpolateFunction(tileRequest))
-      .otherwise(createMarkFailedFunction(tileRequest));
+    var tilePromise;
+
+    // PROPELLER HACK: Allow fail on requestTileGeometry fail
+
+    if (failResultOnTileFail) {
+      tilePromise = requestPromise.then(createInterpolateFunction(tileRequest));
+    } else {
+      tilePromise = requestPromise
+        .then(createInterpolateFunction(tileRequest))
+        .otherwise(createMarkFailedFunction(tileRequest));
+    }
     tilePromises.push(tilePromise);
   }
 

--- a/Source/Renderer/ComputeCommand.js
+++ b/Source/Renderer/ComputeCommand.js
@@ -70,6 +70,15 @@ function ComputeCommand(options) {
   this.postExecute = options.postExecute;
 
   /**
+   * Function that is called when the command is canceled
+   *
+   * @type {Function}
+   * @default undefined
+   */
+  // PROPELLER HACK
+  this.canceled = options.canceled;
+
+  /**
    * Whether the renderer resources will persist beyond this call. If not, they
    * will be destroyed after completion.
    *

--- a/Source/Scene/Camera.js
+++ b/Source/Scene/Camera.js
@@ -29,6 +29,34 @@ import CameraFlightPath from "./CameraFlightPath.js";
 import MapMode2D from "./MapMode2D.js";
 import SceneMode from "./SceneMode.js";
 
+//PROPELLER HACK
+function clampSphere(sphere, position, result) {
+  if (
+    !defined(sphere) ||
+    !defined(position) ||
+    !position ||
+    Cartesian3.equals(position, Cartesian3.ZERO)
+  ) {
+    return position;
+  }
+
+  result = Cartesian3.clone(position, result);
+  if (Cartesian3.distance(result, sphere.center) <= sphere.radius) {
+    return result;
+  }
+  var directionVector = new Cartesian3();
+  directionVector = Cartesian3.normalize(
+    Cartesian3.subtract(result, sphere.center, directionVector),
+    directionVector
+  );
+  directionVector = Cartesian3.multiplyByScalar(
+    directionVector,
+    sphere.radius,
+    directionVector
+  );
+  return Cartesian3.add(sphere.center, directionVector, result);
+}
+
 /**
  * The camera is defined by a position, orientation, and view frustum.
  * <br /><br />
@@ -67,6 +95,8 @@ function Camera(scene) {
   }
   //>>includeEnd('debug');
   this._scene = scene;
+  //PROPELLER HACK
+  this.boundingSphere = undefined;
 
   this._transform = Matrix4.clone(Matrix4.IDENTITY);
   this._invTransform = Matrix4.clone(Matrix4.IDENTITY);
@@ -655,6 +685,14 @@ function updateMembers(camera) {
 
     // Compute the Cartographic position of the camera.
     if (mode === SceneMode.SCENE3D || mode === SceneMode.MORPHING) {
+      //PROPELLER HACK
+      if (camera.boundingSphere) {
+        clampSphere(
+          camera.boundingSphere,
+          camera._positionWC,
+          camera._positionWC
+        );
+      }
       camera._positionCartographic = camera._projection.ellipsoid.cartesianToCartographic(
         camera._positionWC,
         camera._positionCartographic
@@ -1420,7 +1458,12 @@ Camera.prototype.setView = function (options) {
     );
     convert = false;
   }
-
+  //PROPELLER HACK
+  if (typeof destination !== "undefined") {
+    if (this.boundingSphere) {
+      clampSphere(this.boundingSphere, destination, destination);
+    }
+  }
   if (defined(orientation.direction)) {
     orientation = directionUpToHeadingPitchRoll(
       this,

--- a/Source/Scene/ImageryLayer.js
+++ b/Source/Scene/ImageryLayer.js
@@ -1235,6 +1235,11 @@ ImageryLayer.prototype._reprojectTexture = function (
         imagery.state = ImageryState.READY;
         imagery.releaseReference();
       },
+      // PROPELLER HACK
+      canceled: function () {
+        imagery.state = ImageryState.TEXTURE_LOADED;
+        imagery.releaseReference();
+      },
     });
     this._reprojectComputeCommands.push(computeCommand);
   } else {
@@ -1268,6 +1273,12 @@ ImageryLayer.prototype.queueReprojectionCommands = function (frameState) {
  * @private
  */
 ImageryLayer.prototype.cancelReprojections = function () {
+  // PROPELLER HACK
+  this._reprojectComputeCommands.forEach(function (command) {
+    if (command.canceled) {
+      command.canceled();
+    }
+  });
   this._reprojectComputeCommands.length = 0;
 };
 

--- a/Specs/TypeScript/index.ts
+++ b/Specs/TypeScript/index.ts
@@ -96,7 +96,7 @@ import {
   WallOutlineGeometry,
   WebMapServiceImageryProvider,
   WebMapTileServiceImageryProvider,
-} from "cesium";
+} from "@propelleraero/cesium";
 
 // Verify ImageryProvider instances conform to the expected interface
 let imageryProvider: ImageryProvider;

--- a/codeship-services.yml
+++ b/codeship-services.yml
@@ -1,0 +1,5 @@
+builder:
+  encrypted_env_file: deployment/encrypted/build_args.sec
+  build:
+    dockerfile: deployment/Dockerfile
+    encrypted_args_file: deployment/encrypted/build_args.sec

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -1,0 +1,8 @@
+- name: Test
+  service: builder
+  command: yarn test
+
+- name: Build and Deploy
+  tag: master
+  service: builder
+  command: ./deployment/publish.sh

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -3,6 +3,6 @@
   command: yarn test
 
 - name: Build and Publish
-  tag: ^(release-\d*.\d*.\d*.*)
+  tag: ^(propeller-\d*.\d*.\d*.*)
   service: builder
   command: ./deployment/publish.sh

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -2,7 +2,7 @@
   service: builder
   command: yarn test
 
-- name: Build and Deploy
-  tag: master
+- name: Build and Publish
+  tag: ^(release-\d*.\d*.\d*.*)
   service: builder
   command: ./deployment/publish.sh

--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -1,0 +1,26 @@
+FROM node:10.16.2 AS Builder
+
+ARG NPM_TOKEN
+
+# Configure git to use our custom credential helper that can use the $GITHUB_KEY env var
+# This allows us to use the github token without writing it to disk. The sleep is required
+# to avoid a race condition on some systems.
+# https://git-scm.com/docs/api-credentials#_credential_helpers
+
+ARG GITHUB_KEY
+
+RUN git config --global credential.helper "!f() { sleep 0.1; echo 'username=${GITHUB_KEY}\npassword=x-oauth-basic'; }; f" && git config --global url."https://github.com/".insteadOf "git@github.com:"
+
+WORKDIR /build
+
+# Move the package into the container
+COPY . /build
+
+# Configure yarn to use NPM registry
+RUN yarn config set registry "https://registry.npmjs.org"
+
+# Set authToken for access to @propelleraero/* packages.
+RUN npm config set "//registry.npmjs.org/:_authToken" ${NPM_TOKEN}
+
+# Dependencies
+RUN yarn install

--- a/deployment/build.sh
+++ b/deployment/build.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -e
+set -u
+
+yarn release
+
+ls -l

--- a/deployment/crypto.sh
+++ b/deployment/crypto.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+#
+# CRYPTO.SH
+#
+# Encrypts/decrypts contents of a folder using Codeship's jet cli.
+#
+# Usage:
+#   ./crypto encrypt folder destination
+#   ./crypto decrypt folder destination
+#
+
+usage() {
+    echo $"Usage: `basename $0` <encrypt|decrypt> <input> [output]"
+    exit 1
+}
+
+DEPLOYMENT_PATH=$(dirname $0)
+ENCRYPTED_PATH="$DEPLOYMENT_PATH/encrypted"
+SECRETS_PATH="$DEPLOYMENT_PATH/secrets"
+KEY_PATH="$DEPLOYMENT_PATH/codeship.aes" # todo: getopts --key-path
+
+ARGC=$#
+CMD=$1
+IN_DIR=$2
+OUT_DIR=$3
+
+# Do we have at least the input directory
+if [ ! "$ARGC" -gt 1 ]; then usage; fi
+
+# output directory exists or create it
+if [ -z "$OUT_DIR" ]; then OUT_DIR=$(pwd); fi
+if [ ! -e "$OUT_DIR" ]; then mkdir -p "$OUT_DIR"; fi
+
+# output is a directory
+if [ ! -d "$OUT_DIR" ]
+then
+  echo "ERROR: <output> is not a directory."
+  usage
+fi
+
+# input is a directory
+if [ ! -d "$IN_DIR" ]
+then
+  echo "ERROR: <input> is not a directory or doesn't exist."
+  usage
+fi
+
+# Check if codeship jet is installed
+if ! (hash jet 2>/dev/null)
+then
+  echo "ERROR: jet is not installed. https://documentation.codeship.com/pro/jet-cli/installation/"
+  exit 1
+fi
+
+# Check if we have the key
+if [ ! -f "$KEY_PATH" ]
+then
+  echo "Key file missing. Download the project's AES key from Codeship and copy it to ./deployment directory."
+  exit 1
+fi
+
+# encrypt/decrypt
+case "$CMD" in
+  encrypt)
+    for file in $IN_DIR/*
+    do
+      out="$OUT_DIR/$(basename $file).sec"
+      jet encrypt --key-path $KEY_PATH $file $out
+      echo "[encrypted] $file > $out"
+    done
+    ;;
+  decrypt)
+    for file in $IN_DIR/*.sec
+    do
+      out="$OUT_DIR/$(basename -s .sec $file)"
+      jet decrypt --key-path $KEY_PATH $file $out
+      echo "[decrypted] $file > $out"
+    done
+    ;;
+  *)
+    usage
+    exit 1
+esac

--- a/deployment/encrypted/build_args.sec
+++ b/deployment/encrypted/build_args.sec
@@ -1,0 +1,2 @@
+codeship:v2
+O0rejOQU+pyyfX7cNe0k+bK5ClL+C8qVbSGb+6R5AGy6ugDIn8mrly2JNNhiCYBKDjJLHr5Fqy61gtmYa50AxZNKNOfxsqsBDCnu/vFUSnsFbcVnYVfjJrda0KiO5JU=

--- a/deployment/publish.sh
+++ b/deployment/publish.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -e
+set -u
+
+PACKAGE_VERSION=$(cat package.json | grep version | head -1 | awk -F: '{ print $2 }' | sed 's/[\",]//g' | tr -d '[[:space:]]')
+PACKAGE_NAME=$(cat package.json | grep name | head -1 | awk -F: '{ print $2 }' | sed 's/[\",]//g' | tr -d '[[:space:]]')
+PUBLISHED_VERSION=$(npm view $PACKAGE_NAME version || echo '0.0.0')
+
+echo $PUBLISHED_VERSION "->" $PACKAGE_VERSION
+
+if [[ $PACKAGE_VERSION == $PUBLISHED_VERSION ]]
+then
+  echo "Version $PACKAGE_VERSION is same as npm published version! Not publishing."
+  exit 0
+fi
+
+yarn clean
+
+yarn release
+
+npm publish
+
+# git tag $PACKAGE_VERSION && git push origin $PACKAGE_VERSION

--- a/gulpfile.cjs
+++ b/gulpfile.cjs
@@ -1557,7 +1557,7 @@ function createTypeScriptDefinitions() {
 
   // Wrap the source to actually be inside of a declared cesium module
   // and add any workaround and private utility types.
-  source = `declare module "cesium" {
+  source = `declare module "@propelleraero/cesium" {
 
 /**
  * Private interfaces to support PropertyBag being a dictionary-like object.
@@ -1582,7 +1582,7 @@ ${source}
     var assignmentName = path.basename(file, path.extname(file));
     if (publicModules.has(assignmentName)) {
       publicModules.delete(assignmentName);
-      source += `declare module "cesium/Source/${moduleId}" { import { ${assignmentName} } from 'cesium'; export default ${assignmentName}; }\n`;
+      source += `declare module "@propelleraero/cesium/Source/${moduleId}" { import { ${assignmentName} } from '@propelleraero/cesium'; export default ${assignmentName}; }\n`;
     }
   });
 

--- a/index.cjs
+++ b/index.cjs
@@ -4,7 +4,12 @@
 var path = require("path");
 
 // If in 'production' mode, use the combined/minified/optimized version of Cesium
-if (process.env.NODE_ENV === "production") {
+// PROPELLER HACK: Use minified code in all deployed lambda environments for compactness
+if (
+  process.env.NODE_ENV === "production" ||
+  process.env.NODE_ENV === "staging" ||
+  process.env.NODE_ENV === "dev"
+) {
   module.exports = require(path.join(__dirname, "Build/Cesium/Cesium"));
   return;
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "cesium",
-  "version": "1.73.0",
-  "description": "CesiumJS is a JavaScript library for creating 3D globes and 2D maps in a web browser without a plugin.",
+  "name": "@propelleraero/cesium",
+  "version": "1.73.1",
+  "description": "Propeller fork of Cesium.",
   "homepage": "http://cesium.com/cesiumjs/",
   "license": "Apache-2.0",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@propelleraero/cesium",
-  "version": "1.73.1",
+  "version": "1.73.2",
   "description": "Propeller fork of Cesium.",
   "homepage": "http://cesium.com/cesiumjs/",
   "license": "Apache-2.0",

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -xe
+
+PACKAGE_VERSION=$(node -p -e "require('./package.json').version")
+RELEASE_TAG="propeller-$PACKAGE_VERSION"
+
+echo "About to release tag $RELEASE_TAG"
+
+git tag -a "$RELEASE_TAG"
+git push origin "$RELEASE_TAG"


### PR DESCRIPTION
I'm proposing a rework of how we release Cesium.

- Use an interactive rebase to keep our changes at the top of the history as a single commit.
- Release from a release tag rather than master.  This way we're forced to keep a papertrail of everything that gets released rather than relying on a developer to manually tag after publishing a new version.

The nature of this change is that we'll be constantly rewriting the history of master whenever we do a release which makes the release tagging all the more important.

Also I'm happy to try these steps (and fine tune if required) next month when CesiumGS lock off the October release.